### PR TITLE
Perceived enhancements to the sign up feature specs

### DIFF
--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -1,6 +1,22 @@
 require 'features/features_helper'
 
 feature "Sign up", :js do
+
+  context "The sign up page" do
+    before do
+      visit(new_user_registration_path)
+    end
+
+    it "has a form with email address, password, and password confirmation fields" do
+      [ 'email', 'password', 'password_confirmation' ].each do |field_name|
+        page.should have_selector "input#user_" + field_name
+      end
+    end
+
+    it "has a link to the sign in page, for people who already have an account" do
+      page.should have_selector( "a[href='#{new_user_session_path}']" )
+    end
+  end
   
   context "When signing up" do
 

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -48,54 +48,51 @@ feature "Sign up", :js do
     def there_is_a_notification_on_the_page( text_of_the_notification )
       expect(page).to have_selector "#error_explanation li", text: text_of_the_notification
     end
-    context "When the required fields are not filled in" do
-      before do
-        visit new_user_registration_path
-        click_button "Sign up"
-      end
 
-      it "the user is notified that each of the required fields must be provided" do
-        there_is_a_notification_on_the_page "Email can't be blank"
-        there_is_a_notification_on_the_page "Password can't be blank"
-      end
-    end
+    a_password_that_is_130_chars_long = "12345678901234567890" * 13
 
-    context "When the password confirmation does not match the provided password" do
-      before do
-        fill_out_signup_form_and_submit password: "asdf12345678", password_confirmation: "12345678asdf"
-      end
-      it "notifies the user" do
-        there_is_a_notification_on_the_page "Password doesn't match confirmation"
-      end
-    end
-
-    context "When the password is too short" do
-      before do
-        fill_out_signup_form_and_submit password: "1234567"
-      end
-      it "notifies the user" do
-        there_is_a_notification_on_the_page "Password is too short (minimum is 8 characters)"
-      end
-    end
-
-    context "When the password is too long" do
-      before do
-        a_password_that_is_130_chars_long = "12345678901234567890" * 13
-        fill_out_signup_form_and_submit password: a_password_that_is_130_chars_long
-      end
-      it "notifies the user" do
-        there_is_a_notification_on_the_page "Password is too long (maximum is 128 characters)"
+    [
+      {
+        context: "When the required fields are not filled in",
+        signup_inputs: {},
+        expected_notifications: [ "Email can't be blank", "Password can't be blank" ]
+      },
+      {
+        context: "When the password confirmation does not match the provided password",
+        signup_inputs: { password: "asdf12345678", password_confirmation: "12345678asdf" },
+        expected_notifications: [ "Password doesn't match confirmation" ]
+      },
+      {
+        context: "When the password is too short",
+        signup_inputs: { password: "1234567" },
+        expected_notifications: [ "Password is too short (minimum is 8 characters)" ]
+      },
+      {
+        context: "When the password is too long",
+        signup_inputs: { password: a_password_that_is_130_chars_long },
+        expected_notifications: [ "Password is too long (maximum is 128 characters)" ]
+      },
+    ].each do |possible_failure_case|
+      context possible_failure_case[ :context ] do
+        before do
+          fill_out_signup_form_and_submit possible_failure_case[ :signup_inputs ]
+        end
+        possible_failure_case[ :expected_notifications ].each do |expected_notification_text|
+          it 'the user is notified: "' + expected_notification_text + '"' do
+            there_is_a_notification_on_the_page expected_notification_text
+          end
+        end
       end
     end
 
     context "When they provide an email address that is already signed up" do
-      before do
-        user = FactoryGirl.create :user, email: 'email@example.com'
-        fill_out_signup_form_and_submit email: user.email
-      end
-      it "notifies the user" do
-        there_is_a_notification_on_the_page "Email has already been taken"
-      end
+        before do
+          an_email_address_that_is_already_signed_up = FactoryGirl.create( :user, email: 'email@example.com' ).email
+          fill_out_signup_form_and_submit email: an_email_address_that_is_already_signed_up 
+        end
+        it 'the user is notified: "Email has already been taken"' do
+          there_is_a_notification_on_the_page "Email has already been taken"
+        end
     end
   end
 end

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -1,14 +1,6 @@
 require 'features/features_helper'
 
 feature "Sign up", :js do
-  def fill_out_signup_form_and_submit( input_values )
-    visit new_user_registration_path
-    input_values.each do |name, value|
-      fill_in "user_" + name.to_s, with: value
-    end
-
-    click_button "Sign up"
-  end
 
   context "The sign up page" do
     before do
@@ -45,13 +37,7 @@ feature "Sign up", :js do
   end
 
   describe "Failure cases" do
-    def there_is_a_notification_on_the_page( text_of_the_notification )
-      expect(page).to have_selector "#error_explanation li", text: text_of_the_notification
-    end
-
-    a_password_that_is_130_chars_long = "12345678901234567890" * 13
-
-    [
+    confirm_these_possible_signup_failure_cases_are_handled [
       {
         context: "When the required fields are not filled in",
         signup_inputs: {},
@@ -69,21 +55,10 @@ feature "Sign up", :js do
       },
       {
         context: "When the password is too long",
-        signup_inputs: { password: a_password_that_is_130_chars_long },
+        signup_inputs: { password: a_password_that_is_130_chars_long = "12345678901234567890" * 13 },
         expected_notifications: [ "Password is too long (maximum is 128 characters)" ]
       },
-    ].each do |possible_failure_case|
-      context possible_failure_case[ :context ] do
-        before do
-          fill_out_signup_form_and_submit possible_failure_case[ :signup_inputs ]
-        end
-        possible_failure_case[ :expected_notifications ].each do |expected_notification_text|
-          it 'the user is notified: "' + expected_notification_text + '"' do
-            there_is_a_notification_on_the_page expected_notification_text
-          end
-        end
-      end
-    end
+    ]
 
     context "When they provide an email address that is already signed up" do
         before do

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -4,37 +4,58 @@ feature "Sign up", :js do
 
   context "The sign up page" do
     before do
-      visit(new_user_registration_path)
+      visit new_user_registration_path
     end
 
     it "has a form with email address, password, and password confirmation fields" do
       [ 'email', 'password', 'password_confirmation' ].each do |field_name|
-        page.should have_selector "input#user_" + field_name
+        expect(page).to have_selector "input#user_" + field_name
       end
     end
 
     it "has a link to the sign in page, for people who already have an account" do
-      page.should have_selector( "a[href='#{new_user_session_path}']" )
+      expect(page).to have_selector "a[href='#{new_user_session_path}']"
     end
   end
   
-  context "When signing up" do
-
-    before do
-      visit(new_user_registration_path)
-      # sign up form fill out with capybara
-
-      # fill out form and submit
+  context "When the user signs up successfully" do
+    def fill_out_signup_form_and_submit
       fill_in "user_email", with: "gannon@email.com"
       fill_in "user_password", with: "asdf12345678"
       fill_in "user_password_confirmation", with: "asdf12345678"
       click_button "Sign up"
     end
 
-    it "Should flash success and log in" do
-      page.should have_selector("body p.notice", text: "Welcome! You have signed up successfully.")
-      page.should have_selector("nav.user ul li a", text: "Sign out")
+    before do
+      visit new_user_registration_path
+      fill_out_signup_form_and_submit
     end
 
+    it "they end up on the home page of the site" do
+      expect(current_path).to eq root_path
+    end
+
+    it "they get signed in, so a sign out link is present" do
+      expect(page).to have_selector "a[href='#{destroy_user_session_path}']"
+    end
+
+    it "a confirmation notice is shown" do
+      expect(page).to have_selector "body p.notice", text: "Welcome! You have signed up successfully."
+    end
+  end
+
+  describe "Failure cases" do
+    context "When one or more of the required fields are not filled in" do
+      before do
+        visit new_user_registration_path
+        click_button "Sign up"
+      end
+
+      context "Missing email address" do
+        it "the user is notified that the email address is required" do
+          expect(page).to have_selector "#error_explanation li", text: "Email can't be blank"
+        end
+      end
+    end
   end
 end

--- a/spec/features/support/signup.rb
+++ b/spec/features/support/signup.rb
@@ -1,0 +1,27 @@
+def confirm_these_possible_signup_failure_cases_are_handled( possible_failure_cases )
+  possible_failure_cases.each do |possible_failure_case|
+    context possible_failure_case[ :context ] do
+      before do
+        fill_out_signup_form_and_submit possible_failure_case[ :signup_inputs ]
+      end
+      possible_failure_case[ :expected_notifications ].each do |expected_notification_text|
+        it 'the user is notified: "' + expected_notification_text + '"' do
+          there_is_a_notification_on_the_page expected_notification_text
+        end
+      end
+    end
+  end
+end
+
+def fill_out_signup_form_and_submit( input_values )
+  visit new_user_registration_path
+  input_values.each do |name, value|
+    fill_in "user_" + name.to_s, with: value
+  end
+
+  click_button "Sign up"
+end
+
+def there_is_a_notification_on_the_page( text_of_the_notification )
+  expect(page).to have_selector "#error_explanation li", text: text_of_the_notification
+end

--- a/spec/features/support/signup.rb
+++ b/spec/features/support/signup.rb
@@ -14,7 +14,7 @@ def confirm_these_possible_signup_failure_cases_are_handled( possible_failure_ca
 end
 
 def fill_out_signup_form_and_submit( input_values )
-  visit new_user_registration_path
+  visit_signup_page
   input_values.each do |name, value|
     fill_in "user_" + name.to_s, with: value
   end
@@ -24,4 +24,8 @@ end
 
 def there_is_a_notification_on_the_page( text_of_the_notification )
   expect(page).to have_selector "#error_explanation li", text: text_of_the_notification
+end
+
+def visit_signup_page
+  visit new_user_registration_path
 end


### PR DESCRIPTION
Hello,

I've made these changes to the sign up spec, which I perceive as enhancements. I am mainly measuring the enhancements through use of:

```
rspec --format documentation --order defined
```

Originally, that looked something like:

```
Sign up
  When signing up
    Should flash success and log in
```

After the changes I did, it looks like this:

```
Sign up
  The sign up page
    has a form with email address, password, and password confirmation fields
    has a link to the sign in page, for people who already have an account
  When the user signs up successfully
    they end up on the home page of the site
    they get signed in, so a sign out link is present
    a confirmation notice is shown
  Failure cases
    When required fields are not filled in
      Missing email address
        the user is notified that the email address is required
```

Please let me know what you think!
