### PR TITLE
Added rspec-rails to :development group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :development, :test do
   gem 'rb-inotify', '~> 0.8.8', :require => RUBY_PLATFORM.include?('linux') && 'rb-inotify'
   gem 'growl-rspec', :require => RUBY_PLATFORM.include?('darwin') && 'growl-rspec'
   gem 'selenium-webdriver'
+  gem 'rspec-rails'
 end
 
 group :test do
@@ -41,7 +42,6 @@ group :test do
   gem 'site_prism'
   gem 'guard-rspec'
   gem 'guard-bundler'
-  gem 'rspec-rails'
   gem 'capybara'
   gem 'poltergeist', :git => "https://github.com/jonleighton/poltergeist.git"
   gem 'factory_girl_rails'


### PR DESCRIPTION
The reason I did that is because then there is a 'spec' task in rake, so I can run tests with:
$ bundle exec rake spec.

Not sure whether you care about that. There's another problem on my system, where tests fail unless I create tmp/cache - I'd prefer to keep that dir, empty, in the repository, but let me know if you don't.
