### PR TITLE
Added form-control class for simple_form input fields

### DIFF
--- a/app/inputs/string_input.rb
+++ b/app/inputs/string_input.rb
@@ -1,0 +1,5 @@
+class StringInput < SimpleForm::Inputs::StringInput
+  def input_html_classes
+    super.push 'form-control'
+  end
+end

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -43,5 +43,4 @@ SimpleForm.setup do |config|
   config.form_class = "form-horizontal"
   config.label_class = "col-xs-2 col-sm-2 col-md-2 col-lg-2 control-label"
   #config.input_class = "form-control" #not yet supported
-  config.default_wrapper = :bootstrap
 end


### PR DESCRIPTION
Which, as you probably know, is the class that Bootstrap seems to want to use for most inputs.
