### PR TITLE
Added sort to ensure same order when loading required support files

### DIFF
--- a/spec/features/features_helper.rb
+++ b/spec/features/features_helper.rb
@@ -4,7 +4,7 @@ require 'capybara-screenshot/rspec'
 require 'factory_girl_rails'
 require 'site_prism'
 
-Dir[Rails.root.join("spec/features/support/**/*.rb")].each { |f| require f } 
+Dir[Rails.root.join("spec/features/support/**/*.rb")].sort.each { |f| require f } 
 
 RSpec.configure do | config |
 


### PR DESCRIPTION
The order has to be the same so it does not break CI
